### PR TITLE
chore(ci): add master branch to push trigger

### DIFF
--- a/.github/workflows/android_ci.yaml
+++ b/.github/workflows/android_ci.yaml
@@ -3,6 +3,7 @@ name: Android CI
 on:
   push:
     branches:
+      - master
       - dev
       - feature/*
     tags:


### PR DESCRIPTION
Добавлен триггер на push в ветку master в CI yaml, чтобы корректно отображался статус badge и запускались workflow при мёрже и коммитах в master.